### PR TITLE
install tox-gh-actions

### DIFF
--- a/.github/workflows/python-package.yaml
+++ b/.github/workflows/python-package.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: Install dependencies
       run: |
         pip install setuptools wheel
-        pip install flake8 tox
+        pip install flake8 tox tox-gh-actions
         pip install .
     - name: Lint
       run: |


### PR DESCRIPTION
tox-gh-actions library was missing. installing in during cicd setup. pipeline works now.