### PR TITLE
Import MetaFrame from init lazily

### DIFF
--- a/metaframe/__init__.py
+++ b/metaframe/__init__.py
@@ -1,0 +1,12 @@
+"""metaframe package"""
+# pylint: disable=import-outside-toplevel
+__all__ = ["MetaFrame"]
+
+
+def __getattr__(name):
+    # PEP-562: Lazy loaded attributes on python modules
+    if name == "MetaFrame":
+        from metaframe.metaframe import MetaFrame
+        return MetaFrame
+
+    raise AttributeError(f"module {__name__} has no attribute {name}")

--- a/tests/test_metaframe.py
+++ b/tests/test_metaframe.py
@@ -4,9 +4,9 @@ Unit tests
 
 import unittest
 
-from metaframe.metaframe import MetaFrame
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql import functions as F
+from metaframe import MetaFrame
 
 
 class TestMetaFrame(unittest.TestCase):


### PR DESCRIPTION
This PR applies the suggested implementation in #3 and open to discussion.

Now, users can import MetaFrame from the top-level package. Note that this is working only for python>=3.7.

before;

```
from metaframe.metaframe import MetaFrame
```

after;

```
from metaframe import MetaFrame
```

Closes #3